### PR TITLE
[pom] Switch to only known jdepend officially support java 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 language: java
 script: mvn verify -B
 jdk:
- - oraclejdk8
- - oraclejdk7
+ - openjdk8
  - openjdk7
  - openjdk6

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,3 @@ language: java
 script: mvn verify -B
 jdk:
  - openjdk8
- - openjdk7
- - openjdk6

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
 
   <properties>
     <mavenVersion>2.2.1</mavenVersion>
-    <jdependVersion>2.9.1</jdependVersion>
+    <jdependVersion>2.9.5</jdependVersion>
     <mojo.java.target>1.5</mojo.java.target>
     <scmpublish.content>target/staging/${project.artifactId}</scmpublish.content>
   </properties>
@@ -101,7 +101,7 @@
       <version>3.0.20</version>
     </dependency>
     <dependency>
-      <groupId>jdepend</groupId>
+      <groupId>guru.nidi</groupId>
       <artifactId>jdepend</artifactId>
       <version>${jdependVersion}</version>
     </dependency>


### PR DESCRIPTION
[See here] (https://github.com/nidi3/jdepend/)

While jdepend on all fronts appears now to be unsupported, this will at least get support for jdk 8 working.  I think this should do for an immediate release for 2.1 just to support jdk 8.  Beyond that, if this library is still viable from a maven perspective, I'm more than willing to grab the remainder of the original jdepend and the one that nidi3 took over then divested on to get it back to life.  This at least will get rid of errors everyone is encountering as follows (among others)....

'Unknown constant: 18'
