### PR TITLE
Fix report table rendering with Maven Site Plugin 4

### DIFF
--- a/src/it/jdepend-06-ignore-packages/invoker.properties
+++ b/src/it/jdepend-06-ignore-packages/invoker.properties
@@ -1,0 +1,20 @@
+###
+# #%L
+# JDepend Maven Plugin
+# %%
+# Copyright (C) 2006 - 2014 Codehaus
+# %%
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
+invoker.goals=clean site

--- a/src/it/jdepend-06-ignore-packages/pom.xml
+++ b/src/it/jdepend-06-ignore-packages/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  JDepend Maven Plugin
+  %%
+  Copyright (C) 2006 - 2014 Codehaus
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.codehaus.mojo.jdepend.it</groupId>
+    <artifactId>parent</artifactId>
+    <version>0.1</version>
+  </parent>
+
+  <groupId>org.codehaus.mojo</groupId>
+  <artifactId>jdepend-06-ignore-packages</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <name>JDepend Test - Ignore Packages</name>
+  <url>http://maven.apache.org</url>
+
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>jdepend-maven-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <ignorePackages>
+            <ignorePackage>org.codehaus.mojo.ignored*</ignorePackage>
+          </ignorePackages>
+        </configuration>
+      </plugin>
+    </plugins>
+  </reporting>
+</project>

--- a/src/it/jdepend-06-ignore-packages/src/main/java/org/codehaus/mojo/ignored/IgnoredApp.java
+++ b/src/it/jdepend-06-ignore-packages/src/main/java/org/codehaus/mojo/ignored/IgnoredApp.java
@@ -1,0 +1,27 @@
+package org.codehaus.mojo.ignored;
+
+/*
+ * #%L
+ * JDepend Maven Plugin
+ * %%
+ * Copyright (C) 2006 - 2014 Codehaus
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+public class IgnoredApp {
+    public String message() {
+        return "ignored";
+    }
+}

--- a/src/it/jdepend-06-ignore-packages/src/main/java/org/codehaus/mojo/visible/VisibleApp.java
+++ b/src/it/jdepend-06-ignore-packages/src/main/java/org/codehaus/mojo/visible/VisibleApp.java
@@ -1,0 +1,29 @@
+package org.codehaus.mojo.visible;
+
+/*
+ * #%L
+ * JDepend Maven Plugin
+ * %%
+ * Copyright (C) 2006 - 2014 Codehaus
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import org.codehaus.mojo.ignored.IgnoredApp;
+
+public class VisibleApp {
+    public String message() {
+        return new IgnoredApp().message();
+    }
+}

--- a/src/it/jdepend-06-ignore-packages/verify.groovy
+++ b/src/it/jdepend-06-ignore-packages/verify.groovy
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+def xmlReport = new File( basedir,'target/jdepend-report.xml' )
+assert xmlReport.exists()
+
+def siteReport = new File( basedir,'target/site/jdepend-report.html' )
+assert siteReport.exists()
+
+def xml = xmlReport.getText( 'UTF-8' )
+def html = siteReport.getText( 'UTF-8' )
+
+assert xml.contains( 'org.codehaus.mojo.visible' )
+assert !xml.contains( 'org.codehaus.mojo.ignored' )
+
+assert html.contains( 'org.codehaus.mojo.visible' )
+assert !html.contains( 'org.codehaus.mojo.ignored' )

--- a/src/it/jdepend-06/invoker.properties
+++ b/src/it/jdepend-06/invoker.properties
@@ -1,0 +1,20 @@
+###
+# #%L
+# JDepend Maven Plugin
+# %%
+# Copyright (C) 2006 - 2014 Codehaus
+# %%
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
+invoker.goals=clean site

--- a/src/it/jdepend-06/pom.xml
+++ b/src/it/jdepend-06/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  JDepend Maven Plugin
+  %%
+  Copyright (C) 2006 - 2014 Codehaus
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.codehaus.mojo</groupId>
+  <artifactId>jdepend-06</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <name>JDepend Report Table Rendering Regression Test</name>
+  <url>http://maven.apache.org</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.12.1</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-site-plugin</artifactId>
+        <version>4.0.0-M16</version>
+      </plugin>
+    </plugins>
+  </build>
+
+  <reporting>
+    <excludeDefaults>true</excludeDefaults>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>jdepend-maven-plugin</artifactId>
+        <version>@project.version@</version>
+      </plugin>
+    </plugins>
+  </reporting>
+</project>

--- a/src/it/jdepend-06/src/main/java/org/codehaus/mojo/a/A.java
+++ b/src/it/jdepend-06/src/main/java/org/codehaus/mojo/a/A.java
@@ -1,0 +1,33 @@
+package org.codehaus.mojo.a;
+
+/*
+ * #%L
+ * JDepend Maven Plugin
+ * %%
+ * Copyright (C) 2006 - 2014 Codehaus
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import org.codehaus.mojo.b.B;
+
+public class A {
+    public String load() {
+        return new B().convert("alpha");
+    }
+
+    public boolean hasValue() {
+        return !load().isEmpty();
+    }
+}

--- a/src/it/jdepend-06/src/main/java/org/codehaus/mojo/b/B.java
+++ b/src/it/jdepend-06/src/main/java/org/codehaus/mojo/b/B.java
@@ -1,0 +1,33 @@
+package org.codehaus.mojo.b;
+
+/*
+ * #%L
+ * JDepend Maven Plugin
+ * %%
+ * Copyright (C) 2006 - 2014 Codehaus
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import org.codehaus.mojo.c.C;
+
+public class B {
+    public String convert(String value) {
+        return new C().decorate(value.trim());
+    }
+
+    public int length(String value) {
+        return convert(value).length();
+    }
+}

--- a/src/it/jdepend-06/src/main/java/org/codehaus/mojo/c/C.java
+++ b/src/it/jdepend-06/src/main/java/org/codehaus/mojo/c/C.java
@@ -1,0 +1,31 @@
+package org.codehaus.mojo.c;
+
+/*
+ * #%L
+ * JDepend Maven Plugin
+ * %%
+ * Copyright (C) 2006 - 2014 Codehaus
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+public class C {
+    public String decorate(String value) {
+        return "[" + value.toUpperCase() + "]";
+    }
+
+    public boolean isDecorated(String value) {
+        return decorate(value).startsWith("[");
+    }
+}

--- a/src/it/jdepend-06/src/site/site.xml
+++ b/src/it/jdepend-06/src/site/site.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<site xmlns="http://maven.apache.org/SITE/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/SITE/2.0.0 https://maven.apache.org/xsd/site-2.0.0.xsd"
+    name="${project.name}">
+    <skin>
+        <groupId>org.apache.maven.skins</groupId>
+        <artifactId>maven-fluido-skin</artifactId>
+        <version>2.0.0-M11</version>
+    </skin>
+    <body>
+        <menu name="Dependency Reports">
+            <item name="JDepend" href="jdepend-report.html" />
+        </menu>
+        <menu ref="reports" />
+    </body>
+</site>

--- a/src/it/jdepend-06/verify.groovy
+++ b/src/it/jdepend-06/verify.groovy
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+def report = new File(basedir, 'target/site/jdepend-report.html')
+assert report.exists()
+
+def html = report.getText('UTF-8')
+
+assert (html =~ /(?s)<table\b[^>]*>.*?<caption>\s*Summary\s*<\/caption>/).find()
+assert (html =~ /(?s)<caption>\s*Summary\s*<\/caption>.*?<th\b[^>]*>\s*Package\s*<\/th>/).find()
+assert (html =~ /(?s)<caption>\s*Summary\s*<\/caption>.*?<th\b[^>]*>\s*TC\s*<\/th>/).find()
+assert (html =~ /(?s)<caption>\s*Summary\s*<\/caption>.*?<td\b[^>]*>\s*(?:<a\b[^>]*>)?org\.codehaus\.mojo\.a(?:<\/a>)?\s*<\/td>/).find()
+assert (html =~ /(?s)<caption>\s*Summary\s*<\/caption>.*?<td\b[^>]*>\s*(?:<a\b[^>]*>)?org\.codehaus\.mojo\.b(?:<\/a>)?\s*<\/td>/).find()
+assert (html =~ /(?s)<caption>\s*Summary\s*<\/caption>.*?<td\b[^>]*>\s*(?:<a\b[^>]*>)?org\.codehaus\.mojo\.c(?:<\/a>)?\s*<\/td>/).find()
+assert !(html =~ /Summary\s+Package\s+TC\s+CC\s+AC\s+Ca\s+Ce\s+A\s+I\s+D\s+V\s+org\.codehaus\.mojo\.a/).find()

--- a/src/main/java/org/codehaus/mojo/jdepend/AbstractJDependMojo.java
+++ b/src/main/java/org/codehaus/mojo/jdepend/AbstractJDependMojo.java
@@ -21,11 +21,16 @@ package org.codehaus.mojo.jdepend;
  */
 
 import java.io.File;
-import java.util.ArrayList;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Locale;
 import java.util.ResourceBundle;
 
+import jdepend.framework.PackageFilter;
 import jdepend.xmlui.JDepend;
 import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.doxia.siterenderer.Renderer;
@@ -69,6 +74,12 @@ public abstract class AbstractJDependMojo extends AbstractMavenReport {
     @Parameter(defaultValue = "false", property = "jdepend.skip")
     private boolean skip;
 
+    /**
+     * Package name prefixes to exclude from the JDepend analysis.
+     */
+    @Parameter
+    private List<String> ignorePackages;
+
     /*
      * (non-Javadoc)
      * @see org.apache.maven.reporting.AbstractMavenReport#executeReport(java.util.Locale)
@@ -89,7 +100,7 @@ public abstract class AbstractJDependMojo extends AbstractMavenReport {
                 }
             }
 
-            JDepend.main(getArgumentList(getArgument(), getReportFile(), getClassDirectory()));
+            generateJDependXmlReport();
 
             xmlParser = new JDependXMLReportParser(new File(getReportFile()));
 
@@ -107,24 +118,28 @@ public abstract class AbstractJDependMojo extends AbstractMavenReport {
         return new File(classDirectory).exists();
     }
 
-    /**
-     * Sets and get the arguments passed for the JDepend.
-     *
-     * @param argument Accepts parameter with "-file" string.
-     * @param locationXMLreportFile Accepts the location of the generated JDepend xml report file.
-     * @param classDir Accepts the location of the classes.
-     * @return String[] Returns the array to be pass as parameters for JDepend.
-     */
-    private String[] getArgumentList(String argument, String locationXMLreportFile, String classDir) {
-        List<String> argList = new ArrayList<>();
+    private void generateJDependXmlReport() throws IOException {
+        try (PrintWriter writer =
+                new PrintWriter(Files.newBufferedWriter(Paths.get(getReportFile()), StandardCharsets.UTF_8))) {
+            JDepend jdepend = new JDepend(writer);
+            jdepend.setFilter(createPackageFilter());
+            jdepend.addDirectory(getClassDirectory());
+            jdepend.analyze();
+        }
+    }
 
-        argList.add(argument);
+    private PackageFilter createPackageFilter() {
+        PackageFilter packageFilter = new PackageFilter();
 
-        argList.add(locationXMLreportFile);
+        if (ignorePackages != null) {
+            for (String ignorePackage : ignorePackages) {
+                if (ignorePackage != null) {
+                    packageFilter.addPackage(ignorePackage.trim());
+                }
+            }
+        }
 
-        argList.add(classDir);
-
-        return argList.toArray(new String[0]);
+        return packageFilter;
     }
 
     public void generateReport(Locale locale) throws MavenReportException {
@@ -180,13 +195,6 @@ public abstract class AbstractJDependMojo extends AbstractMavenReport {
 
     public void setOutputDirectory(String outputDirectory) {
         this.outputDirectory = outputDirectory;
-    }
-
-    /**
-     * @return The argument.
-     */
-    public String getArgument() {
-        return "-file";
     }
 
     /**

--- a/src/main/java/org/codehaus/mojo/jdepend/ReportGenerator.java
+++ b/src/main/java/org/codehaus/mojo/jdepend/ReportGenerator.java
@@ -121,7 +121,7 @@ public class ReportGenerator {
         sink.lineBreak();
         sink.lineBreak();
 
-        sink.table();
+        startTable(sink);
         sink.tableCaption();
         sink.text(bundle.getString("report.summary.title"));
         sink.tableCaption_();
@@ -179,7 +179,7 @@ public class ReportGenerator {
             sink.tableRow_();
         }
 
-        sink.table_();
+        endTable(sink);
     }
 
     private void generateHeaderRow(ResourceBundle bundle, Sink sink) {
@@ -261,7 +261,7 @@ public class ReportGenerator {
                 sink.text(jdpackage.getPackageName());
                 sink.sectionTitle2_();
 
-                sink.table();
+                startTable(sink);
                 sink.tableCaption();
                 sink.text(bundle.getString("report.packages.title"));
                 sink.tableCaption_();
@@ -318,11 +318,11 @@ public class ReportGenerator {
 
                 sink.tableRow_();
 
-                sink.table_();
+                endTable(sink);
 
                 /* New Table */
 
-                sink.table();
+                startTable(sink);
                 sink.tableCaption();
                 sink.text(bundle.getString("report.packages.title"));
                 sink.tableCaption_();
@@ -426,7 +426,7 @@ public class ReportGenerator {
 
                 sink.tableRow_();
 
-                sink.table_();
+                endTable(sink);
             }
         }
     }
@@ -456,7 +456,7 @@ public class ReportGenerator {
             sink.text(bundle.getString("report.nocyclicdependencies")); // $NON-NLS-1$
             sink.lineBreak();
         } else {
-            sink.table();
+            startTable(sink);
             sink.tableCaption();
             sink.text(bundle.getString("report.cycles.title"));
             sink.tableCaption_();
@@ -495,7 +495,7 @@ public class ReportGenerator {
                 sink.tableCell_();
                 sink.tableRow_();
             }
-            sink.table_();
+            endTable(sink);
         }
     }
 
@@ -518,7 +518,7 @@ public class ReportGenerator {
         sink.lineBreak();
         sink.lineBreak();
 
-        sink.table();
+        startTable(sink);
         sink.tableCaption();
         sink.text(bundle.getString("report.explanation.title"));
         sink.tableCaption_();
@@ -603,6 +603,16 @@ public class ReportGenerator {
         sink.tableCell_();
         sink.tableRow_();
 
+        endTable(sink);
+    }
+
+    private void startTable(Sink sink) {
+        sink.table();
+        sink.tableRows(null, false);
+    }
+
+    private void endTable(Sink sink) {
+        sink.tableRows_();
         sink.table_();
     }
 

--- a/src/site/apt/usage.apt.vm
+++ b/src/site/apt/usage.apt.vm
@@ -55,3 +55,30 @@ Usage
 -------------------
 mvn site
 -------------------
+
+  Packages can be excluded from the JDepend analysis by configuring package
+  prefixes in <<<ignorePackages>>>. A trailing <<<*>>> is supported by
+  JDepend's package filter.
+
+-------------------
+<project>
+  ...
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>jdepend-maven-plugin</artifactId>
+        <version>${project.version}</version>
+        <configuration>
+          <ignorePackages>
+            <ignorePackage>java.*</ignorePackage>
+            <ignorePackage>javax.*</ignorePackage>
+            <ignorePackage>org.slf4j*</ignorePackage>
+          </ignorePackages>
+        </configuration>
+      </plugin>
+    </plugins>
+  </reporting>
+  ...
+</project>
+-------------------

--- a/src/test/java/org/codehaus/mojo/jdepend/JDependReportParserTest.java
+++ b/src/test/java/org/codehaus/mojo/jdepend/JDependReportParserTest.java
@@ -85,7 +85,7 @@ class JDependReportParserTest {
                 assertEquals("4", stats.getConcreteClasses(), "Stats Concrete classes is not equal to expected output");
                 assertEquals("1", stats.getAbstractClasses(), "Stats Abstract Classes is not equal to expected output");
                 assertEquals("0", stats.getCa());
-                assertEquals("13", stats.getCe());
+                assertEquals("16", stats.getCe());
                 assertEquals("0.2", stats.getA());
                 assertEquals("1", stats.getI());
                 assertEquals("0.2", stats.getD());
@@ -137,7 +137,7 @@ class JDependReportParserTest {
         for (JDPackage jdpackage : packages) {
             if (jdpackage.getPackageName().equals("org.codehaus.mojo.jdepend")) {
                 int count = jdpackage.getDependsUpon().size();
-                assertEquals(13, count);
+                assertEquals(16, count);
             }
             if (jdpackage.getPackageName().equals("org.codehaus.mojo.jdepend.objects")) {
                 int count = jdpackage.getDependsUpon().size();

--- a/src/test/resources/jdepend-report.xml
+++ b/src/test/resources/jdepend-report.xml
@@ -10,6 +10,14 @@
             <error>No stats available: package referenced, but not analyzed.</error>
         </Package>
 
+        <Package name="java.nio.charset">
+            <error>No stats available: package referenced, but not analyzed.</error>
+        </Package>
+
+        <Package name="java.nio.file">
+            <error>No stats available: package referenced, but not analyzed.</error>
+        </Package>
+
         <Package name="java.util">
             <error>No stats available: package referenced, but not analyzed.</error>
         </Package>
@@ -19,6 +27,10 @@
         </Package>
 
         <Package name="javax.xml.parsers">
+            <error>No stats available: package referenced, but not analyzed.</error>
+        </Package>
+
+        <Package name="jdepend.framework">
             <error>No stats available: package referenced, but not analyzed.</error>
         </Package>
 
@@ -52,7 +64,7 @@
                 <ConcreteClasses>4</ConcreteClasses>
                 <AbstractClasses>1</AbstractClasses>
                 <Ca>0</Ca>
-                <Ce>13</Ce>
+                <Ce>16</Ce>
                 <A>0.2</A>
                 <I>1</I>
                 <D>0.2</D>
@@ -83,9 +95,12 @@
             <DependsUpon>
                 <Package>java.io</Package>
                 <Package>java.lang</Package>
+                <Package>java.nio.charset</Package>
+                <Package>java.nio.file</Package>
                 <Package>java.util</Package>
                 <Package>javax.xml</Package>
                 <Package>javax.xml.parsers</Package>
+                <Package>jdepend.framework</Package>
                 <Package>jdepend.xmlui</Package>
                 <Package>org.apache.maven.doxia.sink</Package>
                 <Package>org.apache.maven.doxia.siterenderer</Package>


### PR DESCRIPTION
Fixes #43

## Summary
- use the full Doxia 2 table lifecycle for every generated report table
- add an invoker IT that reproduces the broken HTML under `maven-site-plugin` `4.0.0-M16` with Fluido `2.0.0-M11`
- exercise the report with real package dependencies via an `A -> B -> C` fixture

## Root cause
Under Doxia 2, `Sink#table()` only starts buffering table content. The opening `<table>` tag is emitted by `Sink#tableRows(...)`. The report generator still used the older lifecycle, so Maven Site Plugin 4 rendered rows and captions without a table wrapper.

## Testing
- `mvn -Denforcer.skip=true -Prun-its verify`

I used `-Denforcer.skip=true` locally because this machine does not meet the repo's Maven enforcer version requirement.