### PR TITLE
Add support for ignoring packages in JDepend report

### DIFF
--- a/src/it/jdepend-06-ignore-packages/invoker.properties
+++ b/src/it/jdepend-06-ignore-packages/invoker.properties
@@ -1,0 +1,20 @@
+###
+# #%L
+# JDepend Maven Plugin
+# %%
+# Copyright (C) 2006 - 2014 Codehaus
+# %%
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
+invoker.goals=clean site

--- a/src/it/jdepend-06-ignore-packages/pom.xml
+++ b/src/it/jdepend-06-ignore-packages/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  JDepend Maven Plugin
+  %%
+  Copyright (C) 2006 - 2014 Codehaus
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.codehaus.mojo.jdepend.it</groupId>
+    <artifactId>parent</artifactId>
+    <version>0.1</version>
+  </parent>
+
+  <groupId>org.codehaus.mojo</groupId>
+  <artifactId>jdepend-06-ignore-packages</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <name>JDepend Test - Ignore Packages</name>
+  <url>http://maven.apache.org</url>
+
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>jdepend-maven-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <ignorePackages>
+            <ignorePackage>org.codehaus.mojo.ignored*</ignorePackage>
+          </ignorePackages>
+        </configuration>
+      </plugin>
+    </plugins>
+  </reporting>
+</project>

--- a/src/it/jdepend-06-ignore-packages/src/main/java/org/codehaus/mojo/ignored/IgnoredApp.java
+++ b/src/it/jdepend-06-ignore-packages/src/main/java/org/codehaus/mojo/ignored/IgnoredApp.java
@@ -1,0 +1,27 @@
+package org.codehaus.mojo.ignored;
+
+/*
+ * #%L
+ * JDepend Maven Plugin
+ * %%
+ * Copyright (C) 2006 - 2014 Codehaus
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+public class IgnoredApp {
+    public String message() {
+        return "ignored";
+    }
+}

--- a/src/it/jdepend-06-ignore-packages/src/main/java/org/codehaus/mojo/visible/VisibleApp.java
+++ b/src/it/jdepend-06-ignore-packages/src/main/java/org/codehaus/mojo/visible/VisibleApp.java
@@ -1,0 +1,29 @@
+package org.codehaus.mojo.visible;
+
+/*
+ * #%L
+ * JDepend Maven Plugin
+ * %%
+ * Copyright (C) 2006 - 2014 Codehaus
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import org.codehaus.mojo.ignored.IgnoredApp;
+
+public class VisibleApp {
+    public String message() {
+        return new IgnoredApp().message();
+    }
+}

--- a/src/it/jdepend-06-ignore-packages/verify.groovy
+++ b/src/it/jdepend-06-ignore-packages/verify.groovy
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+def xmlReport = new File( basedir,'target/jdepend-report.xml' )
+assert xmlReport.exists()
+
+def siteReport = new File( basedir,'target/site/jdepend-report.html' )
+assert siteReport.exists()
+
+def xml = xmlReport.getText( 'UTF-8' )
+def html = siteReport.getText( 'UTF-8' )
+
+assert xml.contains( 'org.codehaus.mojo.visible' )
+assert !xml.contains( 'org.codehaus.mojo.ignored' )
+
+assert html.contains( 'org.codehaus.mojo.visible' )
+assert !html.contains( 'org.codehaus.mojo.ignored' )

--- a/src/main/java/org/codehaus/mojo/jdepend/AbstractJDependMojo.java
+++ b/src/main/java/org/codehaus/mojo/jdepend/AbstractJDependMojo.java
@@ -21,11 +21,16 @@ package org.codehaus.mojo.jdepend;
  */
 
 import java.io.File;
-import java.util.ArrayList;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Locale;
 import java.util.ResourceBundle;
 
+import jdepend.framework.PackageFilter;
 import jdepend.xmlui.JDepend;
 import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.doxia.siterenderer.Renderer;
@@ -69,6 +74,12 @@ public abstract class AbstractJDependMojo extends AbstractMavenReport {
     @Parameter(defaultValue = "false", property = "jdepend.skip")
     private boolean skip;
 
+    /**
+     * Package name prefixes to exclude from the JDepend analysis.
+     */
+    @Parameter
+    private List<String> ignorePackages;
+
     /*
      * (non-Javadoc)
      * @see org.apache.maven.reporting.AbstractMavenReport#executeReport(java.util.Locale)
@@ -89,7 +100,7 @@ public abstract class AbstractJDependMojo extends AbstractMavenReport {
                 }
             }
 
-            JDepend.main(getArgumentList(getArgument(), getReportFile(), getClassDirectory()));
+            generateJDependXmlReport();
 
             xmlParser = new JDependXMLReportParser(new File(getReportFile()));
 
@@ -107,24 +118,28 @@ public abstract class AbstractJDependMojo extends AbstractMavenReport {
         return new File(classDirectory).exists();
     }
 
-    /**
-     * Sets and get the arguments passed for the JDepend.
-     *
-     * @param argument Accepts parameter with "-file" string.
-     * @param locationXMLreportFile Accepts the location of the generated JDepend xml report file.
-     * @param classDir Accepts the location of the classes.
-     * @return String[] Returns the array to be pass as parameters for JDepend.
-     */
-    private String[] getArgumentList(String argument, String locationXMLreportFile, String classDir) {
-        List<String> argList = new ArrayList<>();
+    private void generateJDependXmlReport() throws IOException {
+        try (PrintWriter writer =
+                new PrintWriter(Files.newBufferedWriter(Paths.get(getReportFile()), StandardCharsets.UTF_8))) {
+            JDepend jdepend = new JDepend(writer);
+            jdepend.setFilter(createPackageFilter());
+            jdepend.addDirectory(getClassDirectory());
+            jdepend.analyze();
+        }
+    }
 
-        argList.add(argument);
+    private PackageFilter createPackageFilter() {
+        PackageFilter packageFilter = new PackageFilter();
 
-        argList.add(locationXMLreportFile);
+        if (ignorePackages != null) {
+            for (String ignorePackage : ignorePackages) {
+                if (ignorePackage != null) {
+                    packageFilter.addPackage(ignorePackage.trim());
+                }
+            }
+        }
 
-        argList.add(classDir);
-
-        return argList.toArray(new String[0]);
+        return packageFilter;
     }
 
     public void generateReport(Locale locale) throws MavenReportException {
@@ -180,13 +195,6 @@ public abstract class AbstractJDependMojo extends AbstractMavenReport {
 
     public void setOutputDirectory(String outputDirectory) {
         this.outputDirectory = outputDirectory;
-    }
-
-    /**
-     * @return The argument.
-     */
-    public String getArgument() {
-        return "-file";
     }
 
     /**

--- a/src/site/apt/usage.apt.vm
+++ b/src/site/apt/usage.apt.vm
@@ -55,3 +55,30 @@ Usage
 -------------------
 mvn site
 -------------------
+
+  Packages can be excluded from the JDepend analysis by configuring package
+  prefixes in <<<ignorePackages>>>. A trailing <<<*>>> is supported by
+  JDepend's package filter.
+
+-------------------
+<project>
+  ...
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>jdepend-maven-plugin</artifactId>
+        <version>${project.version}</version>
+        <configuration>
+          <ignorePackages>
+            <ignorePackage>java.*</ignorePackage>
+            <ignorePackage>javax.*</ignorePackage>
+            <ignorePackage>org.slf4j*</ignorePackage>
+          </ignorePackages>
+        </configuration>
+      </plugin>
+    </plugins>
+  </reporting>
+  ...
+</project>
+-------------------

--- a/src/test/java/org/codehaus/mojo/jdepend/JDependReportParserTest.java
+++ b/src/test/java/org/codehaus/mojo/jdepend/JDependReportParserTest.java
@@ -85,7 +85,7 @@ class JDependReportParserTest {
                 assertEquals("4", stats.getConcreteClasses(), "Stats Concrete classes is not equal to expected output");
                 assertEquals("1", stats.getAbstractClasses(), "Stats Abstract Classes is not equal to expected output");
                 assertEquals("0", stats.getCa());
-                assertEquals("13", stats.getCe());
+                assertEquals("16", stats.getCe());
                 assertEquals("0.2", stats.getA());
                 assertEquals("1", stats.getI());
                 assertEquals("0.2", stats.getD());
@@ -137,7 +137,7 @@ class JDependReportParserTest {
         for (JDPackage jdpackage : packages) {
             if (jdpackage.getPackageName().equals("org.codehaus.mojo.jdepend")) {
                 int count = jdpackage.getDependsUpon().size();
-                assertEquals(13, count);
+                assertEquals(16, count);
             }
             if (jdpackage.getPackageName().equals("org.codehaus.mojo.jdepend.objects")) {
                 int count = jdpackage.getDependsUpon().size();

--- a/src/test/resources/jdepend-report.xml
+++ b/src/test/resources/jdepend-report.xml
@@ -10,6 +10,14 @@
             <error>No stats available: package referenced, but not analyzed.</error>
         </Package>
 
+        <Package name="java.nio.charset">
+            <error>No stats available: package referenced, but not analyzed.</error>
+        </Package>
+
+        <Package name="java.nio.file">
+            <error>No stats available: package referenced, but not analyzed.</error>
+        </Package>
+
         <Package name="java.util">
             <error>No stats available: package referenced, but not analyzed.</error>
         </Package>
@@ -19,6 +27,10 @@
         </Package>
 
         <Package name="javax.xml.parsers">
+            <error>No stats available: package referenced, but not analyzed.</error>
+        </Package>
+
+        <Package name="jdepend.framework">
             <error>No stats available: package referenced, but not analyzed.</error>
         </Package>
 
@@ -52,7 +64,7 @@
                 <ConcreteClasses>4</ConcreteClasses>
                 <AbstractClasses>1</AbstractClasses>
                 <Ca>0</Ca>
-                <Ce>13</Ce>
+                <Ce>16</Ce>
                 <A>0.2</A>
                 <I>1</I>
                 <D>0.2</D>
@@ -83,9 +95,12 @@
             <DependsUpon>
                 <Package>java.io</Package>
                 <Package>java.lang</Package>
+                <Package>java.nio.charset</Package>
+                <Package>java.nio.file</Package>
                 <Package>java.util</Package>
                 <Package>javax.xml</Package>
                 <Package>javax.xml.parsers</Package>
+                <Package>jdepend.framework</Package>
                 <Package>jdepend.xmlui</Package>
                 <Package>org.apache.maven.doxia.sink</Package>
                 <Package>org.apache.maven.doxia.siterenderer</Package>


### PR DESCRIPTION
Fixes #78.

This adds an `ignorePackages` report configuration option and applies it through JDepend's `PackageFilter` before XML generation, so the generated XML, summary metrics, package details, and cycle output stay consistent.

Verification:
- `mvn test`
- `mvn -Prun-its -Dinvoker.test=jdepend-06-ignore-packages verify`
- `mvn verify -Prun-its`