### PR TITLE
Add a goal to fail the build on package cycles

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Build Status](https://travis-ci.org/mojohaus/jdepend-maven-plugin.svg?branch=master)](https://travis-ci.org/mojohaus/jdepend-maven-plugin)
 
 The [jdepend-maven-plugin](http://www.mojohaus.org/jdepend-maven-plugin/)
-plugin produces a nicely formatted metrics report based on your project.
+plugin produces a nicely formatted metrics report and can fail the build when it finds package dependency cycles.
 
 ## Releasing
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <packaging>maven-plugin</packaging>
 
   <name>JDepend Maven Plugin</name>
-  <description>Maven plugin that generates JDepend reports for your projects.</description>
+  <description>Maven plugin that generates JDepend reports and checks package dependency cycles.</description>
   <inceptionYear>2006</inceptionYear>
 
   <licenses>

--- a/src/it/check-acyclic/invoker.properties
+++ b/src/it/check-acyclic/invoker.properties
@@ -1,0 +1,21 @@
+###
+# #%L
+# JDepend Maven Plugin
+# %%
+# Copyright (C) 2006 - 2014 Codehaus
+# %%
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
+invoker.goals=clean verify
+invoker.buildResult=success

--- a/src/it/check-acyclic/pom.xml
+++ b/src/it/check-acyclic/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  JDepend Maven Plugin
+  %%
+  Copyright (C) 2006 - 2014 Codehaus
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.codehaus.mojo.jdepend.it</groupId>
+    <artifactId>parent</artifactId>
+    <version>0.1</version>
+  </parent>
+
+  <groupId>org.codehaus.mojo</groupId>
+  <artifactId>jdepend-check-acyclic</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <name>JDepend Check - Acyclic Packages</name>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>jdepend-maven-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/check-acyclic/src/main/java/org/codehaus/mojo/api/Api.java
+++ b/src/it/check-acyclic/src/main/java/org/codehaus/mojo/api/Api.java
@@ -1,0 +1,23 @@
+package org.codehaus.mojo.api;
+
+/*
+ * #%L
+ * JDepend Maven Plugin
+ * %%
+ * Copyright (C) 2006 - 2014 Codehaus
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+public class Api {}

--- a/src/it/check-acyclic/src/main/java/org/codehaus/mojo/implementation/Implementation.java
+++ b/src/it/check-acyclic/src/main/java/org/codehaus/mojo/implementation/Implementation.java
@@ -1,0 +1,27 @@
+package org.codehaus.mojo.implementation;
+
+/*
+ * #%L
+ * JDepend Maven Plugin
+ * %%
+ * Copyright (C) 2006 - 2014 Codehaus
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import org.codehaus.mojo.api.Api;
+
+public class Implementation {
+    private Api api;
+}

--- a/src/it/check-acyclic/verify.groovy
+++ b/src/it/check-acyclic/verify.groovy
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+assert new File( basedir, 'target/classes/org/codehaus/mojo/api/Api.class' ).exists()
+assert new File( basedir, 'target/classes/org/codehaus/mojo/implementation/Implementation.class' ).exists()
+
+def buildLog = new File( basedir, 'build.log' )
+assert buildLog.text.contains( 'No package dependency cycles found.' )

--- a/src/it/check-cyclic/invoker.properties
+++ b/src/it/check-cyclic/invoker.properties
@@ -1,0 +1,21 @@
+###
+# #%L
+# JDepend Maven Plugin
+# %%
+# Copyright (C) 2006 - 2014 Codehaus
+# %%
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
+invoker.goals=clean verify
+invoker.buildResult=failure

--- a/src/it/check-cyclic/pom.xml
+++ b/src/it/check-cyclic/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  JDepend Maven Plugin
+  %%
+  Copyright (C) 2006 - 2014 Codehaus
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.codehaus.mojo.jdepend.it</groupId>
+    <artifactId>parent</artifactId>
+    <version>0.1</version>
+  </parent>
+
+  <groupId>org.codehaus.mojo</groupId>
+  <artifactId>jdepend-check-cyclic</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <name>JDepend Check - Cyclic Packages</name>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>jdepend-maven-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/check-cyclic/src/main/java/org/codehaus/mojo/alpha/Alpha.java
+++ b/src/it/check-cyclic/src/main/java/org/codehaus/mojo/alpha/Alpha.java
@@ -1,0 +1,27 @@
+package org.codehaus.mojo.alpha;
+
+/*
+ * #%L
+ * JDepend Maven Plugin
+ * %%
+ * Copyright (C) 2006 - 2014 Codehaus
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import org.codehaus.mojo.beta.Beta;
+
+public class Alpha {
+    private Beta beta;
+}

--- a/src/it/check-cyclic/src/main/java/org/codehaus/mojo/beta/Beta.java
+++ b/src/it/check-cyclic/src/main/java/org/codehaus/mojo/beta/Beta.java
@@ -1,0 +1,27 @@
+package org.codehaus.mojo.beta;
+
+/*
+ * #%L
+ * JDepend Maven Plugin
+ * %%
+ * Copyright (C) 2006 - 2014 Codehaus
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import org.codehaus.mojo.alpha.Alpha;
+
+public class Beta {
+    private Alpha alpha;
+}

--- a/src/it/check-cyclic/verify.groovy
+++ b/src/it/check-cyclic/verify.groovy
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+assert new File( basedir, 'target/classes/org/codehaus/mojo/alpha/Alpha.class' ).exists()
+assert new File( basedir, 'target/classes/org/codehaus/mojo/beta/Beta.class' ).exists()
+
+def buildLog = new File( basedir, 'build.log' )
+assert buildLog.text.contains( 'JDepend check failed: package dependency cycles detected' )
+assert buildLog.text.contains( 'org.codehaus.mojo.alpha -> org.codehaus.mojo.beta -> org.codehaus.mojo.alpha' )

--- a/src/main/java/org/codehaus/mojo/jdepend/JDependCheckMojo.java
+++ b/src/main/java/org/codehaus/mojo/jdepend/JDependCheckMojo.java
@@ -1,0 +1,239 @@
+package org.codehaus.mojo.jdepend;
+
+/*
+ * #%L
+ * JDepend Maven Plugin
+ * %%
+ * Copyright (C) 2006 - 2014 Codehaus
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+import jdepend.framework.JDepend;
+import jdepend.framework.JavaClass;
+import jdepend.framework.JavaPackage;
+import jdepend.framework.ParserListener;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+/**
+ * Checks the compiled project classes for package dependency cycles and fails the build when a cycle is found.
+ */
+@Mojo(name = "check", defaultPhase = LifecyclePhase.VERIFY, threadSafe = true)
+public class JDependCheckMojo extends AbstractMojo implements ParserListener {
+    /**
+     * Directory containing the class files to check.
+     */
+    @Parameter(defaultValue = "${project.build.outputDirectory}", property = "jdepend.classDirectory", required = true)
+    private File classDirectory;
+
+    /**
+     * Skip execution of the plugin.
+     */
+    @Parameter(defaultValue = "false", property = "jdepend.skip")
+    private boolean skip;
+
+    private int parsedClassCount;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        if (skip) {
+            getLog().info("Skipping JDepend cycle check on behalf of user");
+            return;
+        }
+
+        if (classDirectory == null) {
+            throw new MojoExecutionException("The class directory is not configured");
+        }
+
+        if (!classDirectory.exists()) {
+            getLog().info("Skipping JDepend cycle check because the class directory does not exist: " + classDirectory);
+            return;
+        }
+
+        if (!classDirectory.isDirectory()) {
+            throw new MojoExecutionException("The configured class directory is not a directory: " + classDirectory);
+        }
+
+        JDepend analyzer = new JDepend();
+        Collection<?> packages;
+        try {
+            int classFileCount = countClassFiles(classDirectory);
+            parsedClassCount = 0;
+            analyzer.analyzeInnerClasses(true);
+            analyzer.addParseListener(this);
+            analyzer.addDirectory(classDirectory.getAbsolutePath());
+            packages = analyzer.analyze();
+            if (parsedClassCount != classFileCount) {
+                throw new MojoExecutionException("JDepend parsed " + parsedClassCount + " of " + classFileCount
+                        + " class files in " + classDirectory
+                        + "; the remaining class files may be unreadable or use unsupported bytecode");
+            }
+        } catch (IOException | RuntimeException e) {
+            throw new MojoExecutionException("Failed to analyze classes in " + classDirectory, e);
+        }
+
+        List<String> cycles = findCycles(packages);
+        if (!cycles.isEmpty()) {
+            throw new MojoFailureException(formatFailureMessage(cycles));
+        }
+
+        getLog().info("No package dependency cycles found.");
+    }
+
+    @Override
+    public void onParsedJavaClass(JavaClass javaClass) {
+        parsedClassCount++;
+    }
+
+    static List<String> findCycles(Collection<?> packages) {
+        Set<String> cycles = new TreeSet<>();
+
+        sortEfferents(packages);
+
+        for (Object candidate : packages) {
+            JavaPackage javaPackage = (JavaPackage) candidate;
+            List<JavaPackage> path = new ArrayList<>();
+            if (javaPackage.collectCycle(path)) {
+                String cycle = canonicalizeCycle(path);
+                if (cycle != null) {
+                    cycles.add(cycle);
+                }
+            }
+        }
+
+        return new ArrayList<>(cycles);
+    }
+
+    private static void sortEfferents(Collection<?> packages) {
+        for (Object candidate : packages) {
+            JavaPackage javaPackage = (JavaPackage) candidate;
+            Map<String, JavaPackage> efferentsByName = new TreeMap<>();
+            for (Object efferent : javaPackage.getEfferents()) {
+                JavaPackage efferentPackage = (JavaPackage) efferent;
+                efferentsByName.put(efferentPackage.getName(), efferentPackage);
+            }
+            javaPackage.setEfferents(efferentsByName.values());
+        }
+    }
+
+    private static int countClassFiles(File directory) throws IOException {
+        File[] files = directory.listFiles();
+        if (files == null) {
+            throw new IOException("Unable to list " + directory);
+        }
+
+        int count = 0;
+        for (File file : files) {
+            if (file.isDirectory()) {
+                count += countClassFiles(file);
+            } else if (file.isFile()) {
+                if (hasExtension(file.getName(), ".class")) {
+                    count++;
+                } else if (isArchive(file.getName())) {
+                    count += countArchiveClassFiles(file);
+                }
+            }
+        }
+        return count;
+    }
+
+    private static int countArchiveClassFiles(File file) throws IOException {
+        int count = 0;
+        try (JarFile archive = new JarFile(file)) {
+            for (java.util.Enumeration<JarEntry> entries = archive.entries(); entries.hasMoreElements(); ) {
+                if (hasExtension(entries.nextElement().getName(), ".class")) {
+                    count++;
+                }
+            }
+        }
+        return count;
+    }
+
+    private static boolean isArchive(String fileName) {
+        return hasExtension(fileName, ".jar") || hasExtension(fileName, ".war") || hasExtension(fileName, ".zip");
+    }
+
+    private static boolean hasExtension(String fileName, String extension) {
+        int offset = fileName.length() - extension.length();
+        return offset >= 0 && fileName.regionMatches(true, offset, extension, 0, extension.length());
+    }
+
+    private static String canonicalizeCycle(List<JavaPackage> path) {
+        if (path.size() < 2) {
+            return null;
+        }
+
+        String repeatedPackage = path.get(path.size() - 1).getName();
+        int cycleStart = -1;
+        for (int index = 0; index < path.size() - 1; index++) {
+            if (repeatedPackage.equals(path.get(index).getName())) {
+                cycleStart = index;
+                break;
+            }
+        }
+
+        if (cycleStart < 0) {
+            return null;
+        }
+
+        List<String> packageNames = new ArrayList<>();
+        for (int index = cycleStart; index < path.size() - 1; index++) {
+            packageNames.add(path.get(index).getName());
+        }
+
+        int canonicalStart = 0;
+        for (int index = 1; index < packageNames.size(); index++) {
+            if (packageNames.get(index).compareTo(packageNames.get(canonicalStart)) < 0) {
+                canonicalStart = index;
+            }
+        }
+
+        StringBuilder cycle = new StringBuilder();
+        for (int index = 0; index < packageNames.size(); index++) {
+            if (cycle.length() > 0) {
+                cycle.append(" -> ");
+            }
+            cycle.append(packageNames.get((canonicalStart + index) % packageNames.size()));
+        }
+        cycle.append(" -> ").append(packageNames.get(canonicalStart));
+        return cycle.toString();
+    }
+
+    private static String formatFailureMessage(List<String> cycles) {
+        StringBuilder message =
+                new StringBuilder("JDepend check failed: package dependency cycles detected, including:");
+        for (String cycle : cycles) {
+            message.append(System.lineSeparator()).append("  - ").append(cycle);
+        }
+        message.append(System.lineSeparator()).append("Run jdepend:generate to inspect the full dependency report.");
+        return message.toString();
+    }
+}

--- a/src/site/apt/check.apt.vm
+++ b/src/site/apt/check.apt.vm
@@ -1,0 +1,70 @@
+~~~
+~~ #%L
+~~ JDepend Maven Plugin
+~~ %%
+~~ Copyright (C) 2006 - 2014 Codehaus
+~~ %%
+~~ Licensed under the Apache License, Version 2.0 (the "License");
+~~ you may not use this file except in compliance with the License.
+~~ You may obtain a copy of the License at
+~~
+~~      http://www.apache.org/licenses/LICENSE-2.0
+~~
+~~ Unless required by applicable law or agreed to in writing, software
+~~ distributed under the License is distributed on an "AS IS" BASIS,
+~~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~~ See the License for the specific language governing permissions and
+~~ limitations under the License.
+~~ #L%
+~~~
+ ------
+ Checking Package Dependency Cycles
+ ------
+ ------
+ ------
+
+Checking Package Dependency Cycles
+
+  The <<<jdepend:check>>> goal analyzes compiled project classes and fails the build when it finds a package
+  dependency cycle. It does not generate an XML or HTML report.
+
+  Bind the goal to the build to run it during the <<<verify>>> phase:
+
+-------------------
+<project>
+  ...
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>jdepend-maven-plugin</artifactId>
+        <version>${project.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  ...
+</project>
+-------------------
+
+  Run the configured check with:
+
+-------------------
+mvn verify
+-------------------
+
+  When invoking the goal directly, compile the project first:
+
+-------------------
+mvn compile jdepend:check
+-------------------
+
+  The goal uses the same <<<jdepend.classDirectory>>> and <<<jdepend.skip>>> user properties as the report goals.
+  If a cycle is found, the failure message lists representative dependency paths. Run <<<jdepend:generate>>> to
+  inspect the complete package dependency report.

--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -41,9 +41,12 @@ JDepend Maven Plugin
 
   * {{{./generate-no-fork-mojo.html}jdepend:generate-no-fork}} Run JDepend and generate a site report (without forking the life cycle).
 
+  * {{{./check-mojo.html}jdepend:check}} Check compiled classes for package dependency cycles and fail the build when a cycle is found.
+
 * Usage
 
   Instructions on how to use the JDepend Maven Plugin can be found on the {{{./usage.html}usage page}}.
+  See the {{{./check.html}cycle check page}} for build-time package cycle enforcement.
 
 * Examples
 

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -24,6 +24,7 @@
       <item name="Introduction" href="index.html" />
       <item name="Goals" href="plugin-info.html" />
       <item name="Usage" href="usage.html" />
+      <item name="Cycle Check" href="check.html" />
       <item name="FAQ" href="faq.html" />
     </menu>
     <menu name="Examples">

--- a/src/test/java/org/codehaus/mojo/jdepend/JDependCheckMojoTest.java
+++ b/src/test/java/org/codehaus/mojo/jdepend/JDependCheckMojoTest.java
@@ -1,0 +1,114 @@
+package org.codehaus.mojo.jdepend;
+
+/*
+ * #%L
+ * JDepend Maven Plugin
+ * %%
+ * Copyright (C) 2006 - 2014 Codehaus
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.io.File;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+import jdepend.framework.JavaPackage;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JDependCheckMojoTest {
+    @Test
+    void returnsNoCyclesForOneWayDependencies() {
+        JavaPackage api = new JavaPackage("org.example.api");
+        JavaPackage implementation = new JavaPackage("org.example.implementation");
+        implementation.dependsUpon(api);
+
+        assertEquals(Collections.emptyList(), JDependCheckMojo.findCycles(Arrays.asList(api, implementation)));
+    }
+
+    @Test
+    void returnsCanonicalCycleWithoutLeadingPackages() {
+        JavaPackage alpha = new JavaPackage("org.example.alpha");
+        JavaPackage beta = new JavaPackage("org.example.beta");
+        JavaPackage entry = new JavaPackage("org.example.entry");
+
+        alpha.dependsUpon(beta);
+        beta.dependsUpon(alpha);
+        entry.dependsUpon(beta);
+
+        assertEquals(
+                Collections.singletonList("org.example.alpha -> org.example.beta -> org.example.alpha"),
+                JDependCheckMojo.findCycles(Arrays.asList(entry, beta, alpha)));
+    }
+
+    @Test
+    void choosesCycleDeterministicallyWhenSeveralAreAvailable() {
+        JavaPackage alpha = new JavaPackage("org.example.alpha");
+        JavaPackage beta = new JavaPackage("org.example.beta");
+        JavaPackage gamma = new JavaPackage("org.example.gamma");
+
+        alpha.dependsUpon(gamma);
+        alpha.dependsUpon(beta);
+        beta.dependsUpon(alpha);
+        gamma.dependsUpon(alpha);
+
+        assertEquals(
+                Collections.singletonList("org.example.alpha -> org.example.beta -> org.example.alpha"),
+                JDependCheckMojo.findCycles(Arrays.asList(gamma, beta, alpha)));
+    }
+
+    @Test
+    void failsWhenJDependCannotParseEveryClass(@TempDir File classDirectory) throws Exception {
+        Files.write(new File(classDirectory, "Broken.class").toPath(), new byte[] {0, 1, 2, 3});
+
+        JDependCheckMojo mojo = mojoFor(classDirectory);
+
+        MojoExecutionException exception = assertThrows(MojoExecutionException.class, mojo::execute);
+        assertTrue(exception.getMessage().contains("JDepend parsed 0 of 1 class files"));
+    }
+
+    @Test
+    void acceptsClassFilesInsideArchives(@TempDir File classDirectory) throws Exception {
+        File archive = new File(classDirectory, "classes.jar");
+        try (InputStream input = JDependCheckMojo.class.getResourceAsStream("JDependCheckMojo.class");
+                JarOutputStream output = new JarOutputStream(Files.newOutputStream(archive.toPath()))) {
+            output.putNextEntry(new JarEntry("org/codehaus/mojo/jdepend/JDependCheckMojo.class"));
+            byte[] buffer = new byte[4096];
+            for (int read = input.read(buffer); read >= 0; read = input.read(buffer)) {
+                output.write(buffer, 0, read);
+            }
+        }
+
+        mojoFor(classDirectory).execute();
+    }
+
+    private static JDependCheckMojo mojoFor(File classDirectory) throws ReflectiveOperationException {
+        JDependCheckMojo mojo = new JDependCheckMojo();
+        Field classDirectoryField = JDependCheckMojo.class.getDeclaredField("classDirectory");
+        classDirectoryField.setAccessible(true);
+        classDirectoryField.set(mojo, classDirectory);
+        return mojo;
+    }
+}

--- a/src/test/java/org/codehaus/mojo/jdepend/JDependReportParserTest.java
+++ b/src/test/java/org/codehaus/mojo/jdepend/JDependReportParserTest.java
@@ -81,14 +81,14 @@ class JDependReportParserTest {
             if (jdpackage.getPackageName().equals("org.codehaus.mojo.jdepend")) {
                 Stats stats = jdpackage.getStats();
 
-                assertEquals("5", stats.getTotalClasses(), "Stats Total Classes is not equal to expected output");
-                assertEquals("4", stats.getConcreteClasses(), "Stats Concrete classes is not equal to expected output");
+                assertEquals("6", stats.getTotalClasses(), "Stats Total Classes is not equal to expected output");
+                assertEquals("5", stats.getConcreteClasses(), "Stats Concrete classes is not equal to expected output");
                 assertEquals("1", stats.getAbstractClasses(), "Stats Abstract Classes is not equal to expected output");
                 assertEquals("0", stats.getCa());
-                assertEquals("13", stats.getCe());
-                assertEquals("0.2", stats.getA());
+                assertEquals("16", stats.getCe());
+                assertEquals("0.17", stats.getA());
                 assertEquals("1", stats.getI());
-                assertEquals("0.2", stats.getD());
+                assertEquals("0.17", stats.getD());
                 assertEquals("1", stats.getV());
             }
             if (jdpackage.getPackageName().equals("org.codehaus.mojo.jdepend.objects")) {
@@ -113,6 +113,7 @@ class JDependReportParserTest {
             if (jdpackage.getPackageName().equals("org.codehaus.mojo.jdepend")) {
                 List<String> concretes = jdpackage.getConcreteClasses();
 
+                assertTrue(concretes.contains("org.codehaus.mojo.jdepend.JDependCheckMojo"));
                 assertTrue(concretes.contains("org.codehaus.mojo.jdepend.JDependMojo"));
                 assertTrue(concretes.contains("org.codehaus.mojo.jdepend.JDependXMLReportParser"));
                 assertTrue(concretes.contains("org.codehaus.mojo.jdepend.ReportGenerator"));
@@ -137,7 +138,7 @@ class JDependReportParserTest {
         for (JDPackage jdpackage : packages) {
             if (jdpackage.getPackageName().equals("org.codehaus.mojo.jdepend")) {
                 int count = jdpackage.getDependsUpon().size();
-                assertEquals(13, count);
+                assertEquals(16, count);
             }
             if (jdpackage.getPackageName().equals("org.codehaus.mojo.jdepend.objects")) {
                 int count = jdpackage.getDependsUpon().size();

--- a/src/test/resources/jdepend-report.xml
+++ b/src/test/resources/jdepend-report.xml
@@ -14,11 +14,19 @@
             <error>No stats available: package referenced, but not analyzed.</error>
         </Package>
 
+        <Package name="java.util.jar">
+            <error>No stats available: package referenced, but not analyzed.</error>
+        </Package>
+
         <Package name="javax.xml">
             <error>No stats available: package referenced, but not analyzed.</error>
         </Package>
 
         <Package name="javax.xml.parsers">
+            <error>No stats available: package referenced, but not analyzed.</error>
+        </Package>
+
+        <Package name="jdepend.framework">
             <error>No stats available: package referenced, but not analyzed.</error>
         </Package>
 
@@ -48,14 +56,14 @@
 
         <Package name="org.codehaus.mojo.jdepend">
             <Stats>
-                <TotalClasses>5</TotalClasses>
-                <ConcreteClasses>4</ConcreteClasses>
+                <TotalClasses>6</TotalClasses>
+                <ConcreteClasses>5</ConcreteClasses>
                 <AbstractClasses>1</AbstractClasses>
                 <Ca>0</Ca>
-                <Ce>13</Ce>
-                <A>0.2</A>
+                <Ce>16</Ce>
+                <A>0.17</A>
                 <I>1</I>
-                <D>0.2</D>
+                <D>0.17</D>
                 <V>1</V>
             </Stats>
 
@@ -66,6 +74,9 @@
             </AbstractClasses>
 
             <ConcreteClasses>
+                <Class sourceFile="JDependCheckMojo.java">
+                    org.codehaus.mojo.jdepend.JDependCheckMojo
+                </Class>
                 <Class sourceFile="JDependMojo.java">
                     org.codehaus.mojo.jdepend.JDependMojo
                 </Class>
@@ -84,11 +95,14 @@
                 <Package>java.io</Package>
                 <Package>java.lang</Package>
                 <Package>java.util</Package>
+                <Package>java.util.jar</Package>
                 <Package>javax.xml</Package>
                 <Package>javax.xml.parsers</Package>
+                <Package>jdepend.framework</Package>
                 <Package>jdepend.xmlui</Package>
                 <Package>org.apache.maven.doxia.sink</Package>
                 <Package>org.apache.maven.doxia.siterenderer</Package>
+                <Package>org.apache.maven.plugin</Package>
                 <Package>org.apache.maven.plugin.logging</Package>
                 <Package>org.apache.maven.reporting</Package>
                 <Package>org.codehaus.mojo.jdepend.objects</Package>


### PR DESCRIPTION
This adds a new `jdepend:check` goal for enforcing package dependency rules during a normal Maven build.

  Until now, the plugin could generate a JDepend report, but there was no straightforward way to fail the build when a package cycle was introduced. The new goal defaults to the `verify` phase and reports the
  dependency path when it finds a cycle.

  The goal also:

  - supports `jdepend.classDirectory` and `jdepend.skip`
  - produces deterministic cycle messages
  - fails explicitly if JDepend cannot parse every class, instead of potentially reporting a false success
  - skips modules that do not have a compiled classes directory

  I added unit tests, Invoker tests for both cyclic and acyclic projects, and a short usage page.

  This does not attempt to replace the modern bytecode work in #81. Unsupported bytecode is reported clearly, so the check should work naturally with that change once it lands.

  Tested with:

  - `mvn verify -Denforcer.skip=true`
  - Maven Invoker tests for successful and failing builds